### PR TITLE
add gob encoding/decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # psqr
 
-[![Build Status](https://travis-ci.org/narqo/psqr.svg?branch=master)](https://travis-ci.org/narqo/psqr)
-[![GoDoc](https://godoc.org/github.com/narqo/psqr?status.svg)](https://godoc.org/github.com/narqo/psqr)
+[![GoDoc](https://godoc.org/github.com/exaring/psqr?status.svg)](https://godoc.org/github.com/exaring/psqr)
 
 Go implementation of [The P-Square Algorithm for Dynamic Calculation of Quantiles and Histograms Without Storing Observations][1].
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/narqo/psqr
+module github.com/exaring/psqr
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/narqo/psqr
+
+go 1.17

--- a/gob.go
+++ b/gob.go
@@ -1,0 +1,54 @@
+package psqr
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+var (
+	_ gob.GobEncoder = &Quantile{}
+	_ gob.GobDecoder = &Quantile{}
+)
+
+// internalQuantile mimics Quantile while exporting its fields and being itself not exported.
+// This enables easy marshalling without exposing internal structure to consumers.
+type internalQuantile struct {
+	P       float64
+	Filled  bool
+	Pos     [nMarkers]int
+	NPos    [nMarkers]float64
+	DN      [nMarkers]float64
+	Heights []float64
+}
+
+func (q *Quantile) GobEncode() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := gob.NewEncoder(buf).Encode(internalQuantile{
+		P:       q.p,
+		Filled:  q.filled,
+		Pos:     q.pos,
+		NPos:    q.npos,
+		DN:      q.dn,
+		Heights: q.heights,
+	}); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (q *Quantile) GobDecode(data []byte) error {
+	var interim internalQuantile
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&interim); err != nil {
+		return err
+	}
+
+	q.p = interim.P
+	q.filled = interim.Filled
+	q.pos = interim.Pos
+	q.npos = interim.NPos
+	q.dn = interim.DN
+	q.heights = interim.Heights
+
+	return nil
+}

--- a/gob_test.go
+++ b/gob_test.go
@@ -3,7 +3,7 @@ package psqr_test
 import (
 	"testing"
 
-	"github.com/narqo/psqr"
+	"github.com/exaring/psqr"
 )
 
 func TestQuantileMarshalling(t *testing.T) {

--- a/gob_test.go
+++ b/gob_test.go
@@ -1,0 +1,63 @@
+package psqr_test
+
+import (
+	"testing"
+
+	"github.com/narqo/psqr"
+)
+
+func TestQuantileMarshalling(t *testing.T) {
+	quant := psqr.NewQuantile(0.5)
+
+	for i := 0; i < 1000; i++ {
+		quant.Append(float64(i))
+	}
+
+	before := quant.Value()
+
+	marshalled, err := quant.GobEncode()
+	if err != nil {
+		t.Errorf("unexpected encoding error: %s", err)
+	}
+
+	if err := quant.GobDecode(marshalled); err != nil {
+		t.Errorf("unexpected decoding error: %s", err)
+	}
+
+	after := quant.Value()
+
+	if before != after {
+		t.Errorf("encoded/decoded values differ: expected %f != got %f", before, after)
+	}
+}
+
+func TestQuantile_EncodingDecodingAndChanging(t *testing.T) {
+	quant := psqr.NewQuantile(0.5)
+
+	for i := 0; i < 1000; i++ {
+		quant.Append(float64(i))
+	}
+
+	encoded, err := quant.GobEncode()
+	if err != nil {
+		t.Errorf("unexpected encoding error: %s", err)
+	}
+
+	decoded := &psqr.Quantile{}
+
+	if err := decoded.GobDecode(encoded); err != nil {
+		t.Errorf("unexpected decoding error: %s", err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		quant.Append(float64(i))
+		decoded.Append(float64(i))
+	}
+
+	origAfter := quant.Value()
+	decodedAfter := decoded.Value()
+
+	if origAfter != decodedAfter {
+		t.Errorf("encoded/decoded value did not keep internal representation: expected %f != got %f", origAfter, decodedAfter)
+	}
+}


### PR DESCRIPTION
Hi,

I imagine chances are slim of getting this code merged upstream, but better safe than sorry! :)

Thir small PR does a couple of things:

1. add a `go.mod`.
2. make `Quantile` instances serializable via `encoding/gob`.

The `encoding/gob` support is nice for us because we want to keep stats on long-running p-square estimations across deployemnts, so we need to persist the internal state somehow.

I picked `encoding/gob` (as opposed to e.g. `encoding/json`) because I felt a more opaque representation to be more fitting to internal state that is not supposed to be fiddled with.

WDYT?